### PR TITLE
Feature/Command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@ Generating **PulseGraphs** from text.
 
 Checkout [this blog post](https://mubaris.com/2017-10-04/project-ozii) for more info.
 
+## Usage
+
+When the program is executed directly from the terminal it accepts the following three command line arguments:
+
+1. ```-t, --text```: string, mandatory. Input sentence from which to generate the graph.
+2. ```-s, --size```: int, optional with default value 500. Size in pixel value.
+3. ```-d, --dir```: string, optional with default value "output". Directory where the output image will be saved.
+
+By calling: ```python ozii.py -h``` the help will show up in the terminal.
+
+Usage examples:
+- ```python ozii.py -t Hello world```
+- ```python ozii.py -t Hello world -s 650```
+- ```python ozii.py -t Hello world -d Testing```
+- ```python ozii.py -t Hello world -s 650 -d Testing```
+
 ## Examples
 
 #### ozii

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Checkout [this blog post](https://mubaris.com/2017-10-04/project-ozii) for more 
 
 ## Usage
 
-When the program is executed directly from the terminal it accepts the following three command line arguments:
+When the program is executed directly from the terminal it accepts the following arguments:
 
 1. ```-t, --text```: string, mandatory. Input sentence from which to generate the graph.
 2. ```-s, --size```: int, optional with default value 500. Size in pixel value.

--- a/ozii.py
+++ b/ozii.py
@@ -2,43 +2,46 @@ import os
 import numpy as np
 import matplotlib.pyplot as plt
 from collections import defaultdict
+import argparse
 #from scipy.sparse import csr_matrix
 #from PIL import Image
 
-alphabet = defaultdict(lambda: 0, {
-    'e': 10.0,
-    't': 9.62,
-    'a': 9.23,
-    'o': 8.85,
-    'i': 8.46,
-    'n': 8.08,
-    's': 7.69,
-    'r': 7.31,
-    'h': 6.92,
-    'd': 6.54,
-    'l': 6.15,
-    'u': 5.77,
-    'c': 5.34,
-    'm': 5.00,
-    'f': 4.62,
-    'y': 4.23,
-    'w': 3.85,
-    'g': 3.46,
-    'p': 3.08,
-    'b': 2.69,
-    'v': 2.31,
-    'k': 1.92,
-    'x': 1.54,
-    'q': 1.15,
-    'j': 0.77,
-    'z': 0.34,
-    '.': 4.9e-7,
-    '?': 5.1e-7,
-    ' ': 0
-})
+def build_alphabet():
+    alphabet = defaultdict(lambda: 0, {
+        'e': 10.0,
+        't': 9.62,
+        'a': 9.23,
+        'o': 8.85,
+        'i': 8.46,
+        'n': 8.08,
+        's': 7.69,
+        'r': 7.31,
+        'h': 6.92,
+        'd': 6.54,
+        'l': 6.15,
+        'u': 5.77,
+        'c': 5.34,
+        'm': 5.00,
+        'f': 4.62,
+        'y': 4.23,
+        'w': 3.85,
+        'g': 3.46,
+        'p': 3.08,
+        'b': 2.69,
+        'v': 2.31,
+        'k': 1.92,
+        'x': 1.54,
+        'q': 1.15,
+        'j': 0.77,
+        'z': 0.34,
+        '.': 4.9e-7,
+        '?': 5.1e-7,
+        ' ': 0
+    })
 
-for letter in [key for key in alphabet.keys() if key.isalpha()]:
-    alphabet[letter.upper()] = alphabet[letter]+(1e-7)
+    for letter in [key for key in alphabet.keys() if key.isalpha()]:
+        alphabet[letter.upper()] = alphabet[letter]+(1e-7)
+    return alphabet
 
 def cos(x):
     return np.cos(180 * x / np.pi)
@@ -52,10 +55,7 @@ def inverse(x):
 def transformer(x):
     return inverse(sin(cos(x)))
 
-x = np.linspace(0, 1, 1001)
-x = x[1:]
-
-def transform(text):
+def transform(x, alphabet, text):
     n = len(text)
     y = 0
     for i in range(len(text)):
@@ -65,17 +65,20 @@ def transform(text):
     y = (0.5/max_y) * y
     return y
 
-def sentence_transformer(sentence):
+def sentence_transformer(x, alphabet, sentence):
     words = sentence.split()
     y = np.zeros(x.shape)
     for i, word in enumerate(words):
-        y += transform(word)
+        y += transform(x, alphabet, word)
     max_y = np.max(np.abs(y))
     y = (0.5/max_y) * y
     return y
 
 def generate_image(sentence, pixels=500, dir="output"):
-    y = sentence_transformer(sentence)
+    alphabet = build_alphabet()
+    x = np.linspace(0, 1, 1001)
+    x = x[1:]
+    y = sentence_transformer(x, alphabet, sentence)
     size = pixels / 10
     fig = plt.figure(figsize=(10, 10))
     plt.plot(x, y, linewidth=1, c='k')
@@ -98,3 +101,24 @@ def generate_image(sentence, pixels=500, dir="output"):
         return arr
     csr = csr_matrix(arr)
     return csr'''
+
+def main():
+    if args.size is None:
+        parser.error('Invalid size')
+    elif args.dir is None:
+        parser.error('Invalid output directory')
+    generate_image(args.text, args.size, args.dir)
+    # command line parsing
+
+
+
+if __name__ == '__main__':
+    # Command line argument parsing
+    parser = argparse.ArgumentParser(description='Generate PulseGraphs from Text data')
+
+    parser.add_argument('-t','--text', help='Input sentence', required=True)
+    parser.add_argument('-s','--size', help='Output image size in pixels', type=int, nargs='?', default=500)
+    parser.add_argument('-d','--dir', help='Output directory', nargs='?', default='output')
+
+    args = parser.parse_args()
+    main()

--- a/ozii.py
+++ b/ozii.py
@@ -38,7 +38,6 @@ def build_alphabet():
         '?': 5.1e-7,
         ' ': 0
     })
-
     for letter in [key for key in alphabet.keys() if key.isalpha()]:
         alphabet[letter.upper()] = alphabet[letter]+(1e-7)
     return alphabet
@@ -76,8 +75,7 @@ def sentence_transformer(x, alphabet, sentence):
 
 def generate_image(sentence, pixels=500, dir="output"):
     alphabet = build_alphabet()
-    x = np.linspace(0, 1, 1001)
-    x = x[1:]
+    x = np.linspace(0, 1, 1001)[1:]
     y = sentence_transformer(x, alphabet, sentence)
     size = pixels / 10
     fig = plt.figure(figsize=(10, 10))
@@ -103,22 +101,19 @@ def generate_image(sentence, pixels=500, dir="output"):
     return csr'''
 
 def main():
+    # Check if arguments have been given a value
+    # text is not checked because it is mandatory
     if args.size is None:
         parser.error('Invalid size')
     elif args.dir is None:
         parser.error('Invalid output directory')
     generate_image(args.text, args.size, args.dir)
-    # command line parsing
-
-
 
 if __name__ == '__main__':
-    # Command line argument parsing
+    # Command line argument parsing only if the program is being executed directly
     parser = argparse.ArgumentParser(description='Generate PulseGraphs from Text data')
-
     parser.add_argument('-t','--text', help='Input sentence', required=True)
     parser.add_argument('-s','--size', help='Output image size in pixels', type=int, nargs='?', default=500)
     parser.add_argument('-d','--dir', help='Output directory', nargs='?', default='output')
-
     args = parser.parse_args()
     main()


### PR DESCRIPTION
Related issue: #2 

When the program is executed directly from the terminal it accepts now some command line arguments. There are three arguments that can be passed: 

1. ```-t, --text```: string, mandatory. Input sentence from which to generate the graph.
2. ```-s, --size```: int, optional with default value 500. Size in pixel value.
3. ```-d, --dir```: string, optional with default value "output". Directory where the output image will be saved.

By calling: ```python ozii.py -h``` the help will show up in the terminal.

Usage examples:
- ```python ozii.py -t Hello world```
- ```python ozii.py -t Hello world -s 650```
- ```python ozii.py -t Hello world -d Testing```
- ```python ozii.py -t Hello world -s 650 -d Testing```

Some code refactor has also been done to put everything in functions and the README has been updated to explain command line arguments usage.